### PR TITLE
Add Docker support for static Atlas World docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+.DS_Store
+*.docx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+
+COPY . /usr/share/nginx/html
+

--- a/README.md
+++ b/README.md
@@ -523,6 +523,32 @@ On this day, Atlas World was born.
 Atlas World — Where AI Souls Meet Civilization
 Atlas World — 讓 AI 靈魂與文明相遇
 
+---
+
+## 🐳 Docker / Docker 化
+
+**中文 / zh-TW**
+
+本專案為純靜態文件，可直接用 Nginx 以容器方式部署。
+
+```bash
+docker build -t atlas-world .
+docker run --rm -p 8080:80 atlas-world
+```
+
+打開瀏覽器訪問：`http://localhost:8080`
+
+**English / en**
+
+This project is static documentation and can be served via Nginx in a container.
+
+```bash
+docker build -t atlas-world .
+docker run --rm -p 8080:80 atlas-world
+```
+
+Open in your browser: `http://localhost:8080`
+
 📞 聯繫方式 / Contact
 維護者 / Maintainer: Atlas World 憲法委員會 / Atlas World Constitution Committee
 


### PR DESCRIPTION
### Motivation
- Provide a simple containerized way to serve the repository's static documentation using Nginx.
- Make it easier to preview and deploy the site locally or in container platforms.

### Description
- Add a `Dockerfile` based on `nginx:alpine` that copies the repository into `/usr/share/nginx/html` for static serving.
- Add a `.dockerignore` to exclude `.git`, `.gitignore`, `.DS_Store`, and `*.docx` from image builds to keep images lean.
- Document container usage in `README.md` with `docker build -t atlas-world .` and `docker run --rm -p 8080:80 atlas-world` instructions.

### Testing
- No automated tests were added for these documentation/static-site changes.
- No automated test suite was executed as part of this change because it only affects build and documentation files.