### PR TITLE
Add GitHub Pages CI/CD workflow and deployment docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+.DS_Store
+*.docx

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+
+COPY . /usr/share/nginx/html
+

--- a/README.md
+++ b/README.md
@@ -523,6 +523,46 @@ On this day, Atlas World was born.
 Atlas World — Where AI Souls Meet Civilization
 Atlas World — 讓 AI 靈魂與文明相遇
 
+---
+
+## 🐳 Docker / Docker 化
+
+**中文 / zh-TW**
+
+本專案為純靜態文件，可直接用 Nginx 以容器方式部署。
+
+```bash
+docker build -t atlas-world .
+docker run --rm -p 8080:80 atlas-world
+```
+
+打開瀏覽器訪問：`http://localhost:8080`
+
+**English / en**
+
+This project is static documentation and can be served via Nginx in a container.
+
+```bash
+docker build -t atlas-world .
+docker run --rm -p 8080:80 atlas-world
+```
+
+Open in your browser: `http://localhost:8080`
+
+---
+
+## 🚀 GitHub Pages 部署 / GitHub Pages Deployment
+
+**中文 / zh-TW**
+
+已新增 GitHub Actions 流程，當 `main` 分支有更新時會自動部署至 GitHub Pages。
+請到 GitHub 專案的 **Settings → Pages**，將 **Build and deployment** 設為 **GitHub Actions**。
+
+**English / en**
+
+A GitHub Actions workflow is included to deploy on pushes to `main`.
+In your repo settings, go to **Settings → Pages** and set **Build and deployment** to **GitHub Actions**.
+
 📞 聯繫方式 / Contact
 維護者 / Maintainer: Atlas World 憲法委員會 / Atlas World Constitution Committee
 


### PR DESCRIPTION
### Motivation

- Provide a CI/CD pipeline to automatically publish the repository's static documentation to GitHub Pages on updates to `main`.
- Make it easy to preview and serve the site locally using a simple Nginx-based Docker image with `Dockerfile`.
- Document the GitHub Pages setup and local Docker preview steps in `README.md` for quick onboarding.
- Ensure the repository can be deployed via GitHub Actions and optionally triggered manually with `workflow_dispatch`.

### Description

- Add a Pages deployment workflow at `.github/workflows/gh-pages.yml` that runs on pushes to `main` and on manual dispatch and uses `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` to publish the site.
- Update `README.md` to include Docker build/run instructions (`docker build -t atlas-world .` and `docker run --rm -p 8080:80 atlas-world`) and GitHub Pages setup guidance to set `Build and deployment` to `GitHub Actions` in repo settings.
- Add a `Dockerfile` that serves the repository as static files using `nginx:alpine` by copying the repo into `/usr/share/nginx/html`.
- Add a `.dockerignore` to exclude `.git`, `.gitignore`, `.DS_Store`, and `*.docx` from image builds to keep images lean.

### Testing

- No automated tests were added for these workflow/docs/build changes.
- No automated test suite was executed as part of this change because it only affects workflow and static site files.